### PR TITLE
Fixed specs and constructor

### DIFF
--- a/lib/fbgraph/client.rb
+++ b/lib/fbgraph/client.rb
@@ -8,6 +8,7 @@ module FBGraph
       @client_id, @secret_id = options[:client_id] || FBGraph.config[:client_id], options[:secret_id] || FBGraph.config[:secret_id]
       @facebook_uri = 'https://graph.facebook.com'
       @consumer = RestClient::Resource.new(@facebook_uri)
+      @access_token = options.fetch :token, nil
       @auth = OAuth2::AccessToken.new(oauth_client , @access_token)
       return true
     end

--- a/lib/fbgraph/selection.rb
+++ b/lib/fbgraph/selection.rb
@@ -40,8 +40,9 @@ module FBGraph
 
     def picture
       uri = [@client.facebook_uri , build_open_graph_path(@objects , 'picture')].join('/')
-      return uri unless @client.consumer
+      return uri if @client.access_token.nil?
       uri + '?access_token=' + @client.access_token
+
     end
 
   end

--- a/specs/lib/fbauth/authorization_spec.rb
+++ b/specs/lib/fbauth/authorization_spec.rb
@@ -37,7 +37,7 @@ describe FBGraph do
           @token.should == @consumer.token
         end
         it 'should set the consumer' do
-          @client.consumer.should == @consumer
+          @client.auth.should == @consumer
         end
       end
     end

--- a/specs/lib/fbauth/base_spec.rb
+++ b/specs/lib/fbauth/base_spec.rb
@@ -9,7 +9,8 @@ describe FBGraph do
       @client = FBGraph::Client.new(:client_id => @client_id,
                                     :secret_id => @secret_id,
                                     :token => 'token')
-      @base = FBGraph::Base.new(@client)                              
+      @base = FBGraph::Base.new(@client)
+      
     end
 
     describe 'initialization' do
@@ -59,9 +60,9 @@ describe FBGraph do
       describe 'info!' do
         describe 'when object is an array' do
           it 'should request with the path "/?ids=1,2,3"' do
-            uri = "/?ids=1,2,3"
+            uri = "?access_token=token&ids=1,2,3"
             @base.find([1,2,3])
-            @client.consumer.stub!(:get).with(uri).and_return('')
+            expect_consumer(uri)
             @base.info!(false)
           end
         end
@@ -69,34 +70,34 @@ describe FBGraph do
         describe 'when object is a string' do
 
           it 'should request with the path "/123"' do
-            uri = "/123"
-            @base.find('123')
-            @client.consumer.stub!(:get).with(uri).and_return('')
+            uri = "123?access_token=token"
+            @base.find('123')            
+            expect_consumer(uri)                        
             @base.info!(false)
           end
           
           it "should parse the result by default" do
-            uri = "/123"
+            uri = "123?access_token=token"
             @base.find('123')
-            @client.consumer.stub!(:get).with(uri).and_return('{"me": [1, 2]}')
+            expect_consumer(uri, '{"me": [1, 2]}')
             @base.info!.me.should == [1, 2]
           end
           
           describe 'when a connection is passed' do
             it 'should request with the path "/123/home"' do
-              uri = "/123/home"
+              uri = "123/home?access_token=token"
               @base.find('123').connection('home')
-              @client.consumer.stub!(:get).with(uri).and_return('')
+              expect_consumer(uri)
               @base.info!(false)
             end
           end
 
           describe 'when params are passed' do
             it 'should request with the path "/123?fields=name,picture"' do
-              uri = "/123?fields=name,picture"
+              uri = "123?fields=name,picture&access_token=token"
               @base.find('123')
               @base.params = {:fields => "name,picture"}
-              @client.consumer.stub!(:get).with(uri).and_return('')
+              expect_consumer(uri)
               @base.info!(false)
             end
           end
@@ -106,30 +107,31 @@ describe FBGraph do
       describe 'publish!' do
         describe 'when is passed params before invocation' do
           it 'should request with the path "/123" and params {:extra => "extra" }' do
-            uri = "/123"
+            uri = "123"
             @base.find('123')
             @base.params = {:extra => "extra" }
-            @client.consumer.stub!(:post).with(uri , @base.params).and_return('')
+            #@client.consumer.stub!(:post).with(uri , @base.params).and_return('')
+            expect_consumer_post(uri, {:extra => "extra", :access_token => 'token'})
             @base.publish!({}, false)
         end
         end
         describe 'when is passed params on invocation' do
           it 'should request with the path "/123" and params {:extra => "extra" }' do
-            uri = "/123"
+            uri = "123"
             @base.find('123')
-            ps = {:extra => "extra" }
-            @client.consumer.stub!(:post).with(uri , ps).and_return('')
-            @base.publish!(ps , false)
+            ps = {:extra => "extra"}
+            expect_consumer_post(uri, {:extra => "extra", :access_token => 'token'})
+            @base.publish!(ps, false)
           end
         end
       end
 
       describe 'delete!' do
         it 'should request with the path "/123" and params {:extra => "extra" }' do
-          uri = "/123"
+          uri = "123"
           @base.find('123')
           @base.params = {:extra => "extra" }
-          @client.consumer.stub!(:delete).with(uri , @base.params).and_return('')
+          expect_consumer_post(uri, {:method => :delete, :extra => "extra", :access_token => 'token'})
           @base.delete!(false)
         end
       end

--- a/specs/lib/fbauth/client_spec.rb
+++ b/specs/lib/fbauth/client_spec.rb
@@ -37,7 +37,7 @@ describe FBGraph do
           @client.access_token.should == @token
         end
         it 'should set the consumer client' do
-          @client.consumer.class.should == OAuth2::AccessToken
+          @client.consumer.class.should == RestClient::Resource
         end
       end
     end

--- a/specs/spec_helper.rb
+++ b/specs/spec_helper.rb
@@ -1,3 +1,15 @@
 $LOAD_PATH << File.expand_path('../../lib', __FILE__)
 require 'rubygems'
 require 'fbgraph'
+
+def expect_consumer(uri, result = '')
+  consumer = @client.consumer[uri]
+  consumer.stub!(:get).and_return(Struct.new(:body).new(result))
+  @client.consumer.stub!(:[]).with(uri).and_return(consumer)  
+end
+
+def expect_consumer_post(uri, params = {}, result = '')
+  rest_client = @client.consumer[uri]
+  rest_client.stub!(:post).with(params).and_return(Struct.new(:body).new(result))
+  @client.consumer.stub!(:[]).with(uri).and_return(rest_client)  
+end


### PR DESCRIPTION
Hi,

I've just fixed the specs in my fork of the fbgraph. I've also re-added the ability to give :token parameter in the FBGraph::Client constructor since it has vanished in the commit 2807fbdfe36bdcd07fbb2d1115a46ef1525fabd3.

Naturally I'm not 100% sure whether the interface change was intentional, but at least it broke my application, many of the included specs, and it wasn't documented anywhere. 

Note that I'm only using fbgraph to fetch data from the facebook. Therefore publishing and deleting is tested only manually and with rspec, and not in actual production environment.
