### PR TITLE
Client.new(:access_token => 'token_key') works now

### DIFF
--- a/lib/fbgraph/client.rb
+++ b/lib/fbgraph/client.rb
@@ -6,6 +6,7 @@ module FBGraph
       
     def initialize(options = {})
       @client_id, @secret_id = options[:client_id] || FBGraph.config[:client_id], options[:secret_id] || FBGraph.config[:secret_id]
+      @access_token ||= options[:access_token]
       @facebook_uri = 'https://graph.facebook.com'
       @consumer = RestClient::Resource.new(@facebook_uri)
       @auth = OAuth2::AccessToken.new(oauth_client , @access_token)


### PR DESCRIPTION
The :access_token option was not included in the Client.new method, this fixes it.

I have renamed it to access_token from token, because it is used all over in examples and stuff like that.
