### PR TITLE
Add app_secret param to parse_signed_request call

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -83,7 +83,7 @@ h3. Canvas
 
 Facebook send a segned_request as a parameter. Can be decoded with the method parse_signed_request of FBGraph::Canvas module
 
-> FBGraph::Canvas.parse_signed_request(params[:signed_request])
+> FBGraph::Canvas.parse_signed_request(app_secret, params[:signed_request])
 
 h3. Selection
 


### PR DESCRIPTION
Trying to run the example code for canvas apps I run into this error:

```
ArgumentError - wrong number of arguments (1 for 2)
```

because parse_signed_request needs 2 params (see https://github.com/nsanta/fbgraph/blob/master/lib/fbgraph/canvas.rb#L6)
