### PR TITLE
Adding Mutual Friends to Selection Connection Types

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -283,4 +283,4 @@ h2. Contributors List
 
 "Matias Käkelä":http://github.com/massive
 
-h4.
+"Max De Marzi":http://github.com/maxdemarzi

--- a/lib/fbgraph/selection.rb
+++ b/lib/fbgraph/selection.rb
@@ -13,7 +13,8 @@ module FBGraph
                           likes inbox outbox updates accounts checkins
                           friendlists platformrequests threads participants
                           former_participants senders messages insights
-                          subscriptions payments apprequests reviews).freeze
+                          subscriptions payments apprequests reviews 
+                          mutualfriends).freeze
 
     OBJECTS.each do |object|
       class_eval  <<-METHOD

--- a/lib/fbgraph/selection.rb
+++ b/lib/fbgraph/selection.rb
@@ -14,7 +14,7 @@ module FBGraph
                           friendlists platformrequests threads participants
                           former_participants senders messages insights
                           subscriptions payments apprequests reviews 
-                          mutualfriends).freeze
+                          mutualfriends family).freeze
 
     OBJECTS.each do |object|
       class_eval  <<-METHOD


### PR DESCRIPTION
Allows:

client.selection.me.mutualfriends(friend_fb_id)

See https://developers.facebook.com/docs/reference/api/user/#mutualfriends for details
